### PR TITLE
Implement undo and redo

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <script src="./scripts/normalize-css-color.js"></script>
   <script src="./scripts/color-conversion-algorithms.js"></script>
   
+  <script src="./scripts/theme-history.js"></script>
   <script src="./scripts/theme.js"></script>
   <script src="./scripts/winclassic.js"></script>
   <script src="./scripts/replace-svg.js"></script>

--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
 
       <div id="controls">
         <div id="meta-controls">
+          <button id="undo-button">Undo</button>
           <label><input type="checkbox" name="link-elements" id="link-elements" checked="checked" /> Link elements</label>
           <label><input type="checkbox" name="use-gradients" id="use-gradients" checked="checked" /> Title bar gradients</label>
         </div>

--- a/index.html
+++ b/index.html
@@ -126,8 +126,8 @@
 
       <div id="controls">
         <div id="meta-controls">
-          <button id="undo-button">Undo</button>
-          <button id="redo-button">Redo</button>
+          <button id="undo-button" accesskey="u">Undo</button>
+          <button id="redo-button" accesskey="r">Redo</button>
           <label><input type="checkbox" name="link-elements" id="link-elements" checked="checked" /> Link elements</label>
           <label><input type="checkbox" name="use-gradients" id="use-gradients" checked="checked" /> Title bar gradients</label>
         </div>

--- a/index.html
+++ b/index.html
@@ -127,6 +127,7 @@
       <div id="controls">
         <div id="meta-controls">
           <button id="undo-button">Undo</button>
+          <button id="redo-button">Redo</button>
           <label><input type="checkbox" name="link-elements" id="link-elements" checked="checked" /> Link elements</label>
           <label><input type="checkbox" name="use-gradients" id="use-gradients" checked="checked" /> Title bar gradients</label>
         </div>

--- a/scripts/theme-history.js
+++ b/scripts/theme-history.js
@@ -22,7 +22,7 @@ ThemeHistory.prototype.undo = function() {
 }
 
 ThemeHistory.prototype.redo = function() {
-  this.undoHistory.push(this.current)
+  this.undoHistory.push(this.current);
   this.current = this.redoHistory.pop();
   return JSON.parse(JSON.stringify(this.current));
 }

--- a/scripts/theme-history.js
+++ b/scripts/theme-history.js
@@ -14,5 +14,12 @@ ThemeHistory.prototype.undo = function() {
   return JSON.parse(JSON.stringify(this.undoHistory[this.undoHistory.length - 1]));
 }
 
+Object.defineProperty(ThemeHistory.prototype, "length", {
+  enumerable: true,
+  get: function() {
+    return this.undoHistory.length;
+  },
+});
+
 return ThemeHistory;
 })();

--- a/scripts/theme-history.js
+++ b/scripts/theme-history.js
@@ -1,0 +1,17 @@
+window.ThemeHistory = (function() {
+function ThemeHistory() {
+  this.undoHistory = [];
+
+  return this;
+}
+
+ThemeHistory.prototype.commit = function(item) {
+  this.undoHistory.push(item);
+}
+
+ThemeHistory.prototype.undo = function() {
+  return this.undoHistory.pop();
+}
+
+return ThemeHistory;
+})();

--- a/scripts/theme-history.js
+++ b/scripts/theme-history.js
@@ -1,23 +1,37 @@
 window.ThemeHistory = (function() {
 function ThemeHistory() {
   this.undoHistory = [];
+  this.redoHistory = [];
 
   return this;
 }
 
 ThemeHistory.prototype.commit = function(item) {
   this.undoHistory.push(JSON.parse(JSON.stringify(item)));
+  this.redoHistory.length = 0;
 }
 
 ThemeHistory.prototype.undo = function() {
-  this.undoHistory.pop();
+  this.redoHistory.push(this.undoHistory.pop());
   return JSON.parse(JSON.stringify(this.undoHistory[this.undoHistory.length - 1]));
 }
 
-Object.defineProperty(ThemeHistory.prototype, "length", {
+ThemeHistory.prototype.redo = function() {
+  this.undoHistory.push(this.redoHistory.pop());
+  return JSON.parse(JSON.stringify(this.undoHistory[this.undoHistory.length - 1]));
+}
+
+Object.defineProperty(ThemeHistory.prototype, "undoLength", {
   enumerable: true,
   get: function() {
     return this.undoHistory.length;
+  },
+});
+
+Object.defineProperty(ThemeHistory.prototype, "redoLength", {
+  enumerable: true,
+  get: function() {
+    return this.redoHistory.length;
   },
 });
 

--- a/scripts/theme-history.js
+++ b/scripts/theme-history.js
@@ -2,23 +2,29 @@ window.ThemeHistory = (function() {
 function ThemeHistory() {
   this.undoHistory = [];
   this.redoHistory = [];
+  this.current = undefined;
 
   return this;
 }
 
 ThemeHistory.prototype.commit = function(item) {
-  this.undoHistory.push(JSON.parse(JSON.stringify(item)));
-  this.redoHistory.length = 0;
+  if (typeof this.current !== "undefined") {
+    this.undoHistory.push(this.current);
+    this.redoHistory.length = 0;
+  }
+  this.current = JSON.parse(JSON.stringify(item));
 }
 
 ThemeHistory.prototype.undo = function() {
-  this.redoHistory.push(this.undoHistory.pop());
-  return JSON.parse(JSON.stringify(this.undoHistory[this.undoHistory.length - 1]));
+  this.redoHistory.push(this.current);
+  this.current = this.undoHistory.pop();
+  return JSON.parse(JSON.stringify(this.current));
 }
 
 ThemeHistory.prototype.redo = function() {
-  this.undoHistory.push(this.redoHistory.pop());
-  return JSON.parse(JSON.stringify(this.undoHistory[this.undoHistory.length - 1]));
+  this.undoHistory.push(this.current)
+  this.current = this.redoHistory.pop();
+  return JSON.parse(JSON.stringify(this.current));
 }
 
 Object.defineProperty(ThemeHistory.prototype, "undoLength", {

--- a/scripts/theme-history.js
+++ b/scripts/theme-history.js
@@ -6,11 +6,12 @@ function ThemeHistory() {
 }
 
 ThemeHistory.prototype.commit = function(item) {
-  this.undoHistory.push(item);
+  this.undoHistory.push(JSON.parse(JSON.stringify(item)));
 }
 
 ThemeHistory.prototype.undo = function() {
-  return this.undoHistory.pop();
+  this.undoHistory.pop();
+  return JSON.parse(JSON.stringify(this.undoHistory[this.undoHistory.length - 1]));
 }
 
 return ThemeHistory;

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -2,6 +2,8 @@ window.Theme = (function(window) {
 
 /* Generic Theme */
 function Theme(items) {
+  this.history = new window.ThemeHistory();
+
   if (Array.isArray(items))
     this.items = items.reduce(function(acc, item) {
       acc[item] = {color: "#000000"};
@@ -87,6 +89,15 @@ Theme.prototype.rippleToLinkedElements = function(itemName) {
     var transformedColor = converter.toRgb.apply(null, transformedComponents);
     this.setItemColor(element, colorComponentConversions.rgb.toCssString.apply(null, transformedColor), false);
   }
+}
+
+Theme.prototype.commit = function() {
+  this.history.commit(this.items);
+}
+
+Theme.prototype.undo = function() {
+  var oldItems = this.history.undo();
+  this.items = oldItems;
 }
 
 function toHexColor(colorNum) {

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -96,8 +96,11 @@ Theme.prototype.commit = function() {
 }
 
 Theme.prototype.undo = function() {
-  var oldItems = this.history.undo();
-  this.items = oldItems;
+  this.items = this.history.undo();
+}
+
+Theme.prototype.redo = function() {
+  this.items = this.history.redo();
 }
 
 function toHexColor(colorNum) {

--- a/scripts/winclassic.js
+++ b/scripts/winclassic.js
@@ -65,6 +65,9 @@ function WinClassicTheme() {
   this.exportDestination = document.getElementById("export");
   this.linkElementsToggle = document.getElementById("link-elements");
   this.useGradientsToggle = document.getElementById("use-gradients");
+  this.undoButton = document.getElementById("undo-button");
+
+  this.undoButton.onclick = this.undo.bind(this);
 
   for (var i = 0; i < this.pickers.length; i++) {
     var picker = this.pickers[i];
@@ -169,6 +172,13 @@ WinClassicTheme.prototype.enableLinkedElements = function(types) {
   }
 
   this.linkedElements = enabledElementLinks;
+}
+
+WinClassicTheme.prototype.undo = function() {
+  Theme.prototype.undo.call(this);
+  this.updateStylesheet();
+  this.resetPickers();
+  this.displayExport();
 }
 
 return WinClassicTheme;

--- a/scripts/winclassic.js
+++ b/scripts/winclassic.js
@@ -66,9 +66,12 @@ function WinClassicTheme() {
   this.linkElementsToggle = document.getElementById("link-elements");
   this.useGradientsToggle = document.getElementById("use-gradients");
   this.undoButton = document.getElementById("undo-button");
+  this.redoButton = document.getElementById("redo-button");
 
   this.undoButton.onclick = this.undo.bind(this);
   this.undoButton.disabled = true;
+  this.redoButton.onclick = this.redo.bind(this);
+  this.redoButton.disabled = true;
 
   for (var i = 0; i < this.pickers.length; i++) {
     var picker = this.pickers[i];
@@ -177,7 +180,8 @@ WinClassicTheme.prototype.enableLinkedElements = function(types) {
 
 WinClassicTheme.prototype.commit = function() {
   Theme.prototype.commit.call(this);
-  this.undoButton.disabled = this.history.length <= 1;
+  this.undoButton.disabled = this.history.undoLength <= 1;
+  this.redoButton.disabled = this.history.redoLength <= 0;
 }
 
 WinClassicTheme.prototype.undo = function() {
@@ -185,7 +189,17 @@ WinClassicTheme.prototype.undo = function() {
   this.updateStylesheet();
   this.resetPickers();
   this.displayExport();
-  this.undoButton.disabled = this.history.length <= 1;
+  this.undoButton.disabled = this.history.undoLength <= 1;
+  this.redoButton.disabled = this.history.redoLength <= 0;
+}
+
+WinClassicTheme.prototype.redo = function() {
+  Theme.prototype.redo.call(this);
+  this.updateStylesheet();
+  this.resetPickers();
+  this.displayExport();
+  this.undoButton.disabled = this.history.undoLength <= 1;
+  this.redoButton.disabled = this.history.redoLength <= 0;
 }
 
 return WinClassicTheme;

--- a/scripts/winclassic.js
+++ b/scripts/winclassic.js
@@ -68,6 +68,7 @@ function WinClassicTheme() {
   this.undoButton = document.getElementById("undo-button");
 
   this.undoButton.onclick = this.undo.bind(this);
+  this.undoButton.disabled = true;
 
   for (var i = 0; i < this.pickers.length; i++) {
     var picker = this.pickers[i];
@@ -174,11 +175,17 @@ WinClassicTheme.prototype.enableLinkedElements = function(types) {
   this.linkedElements = enabledElementLinks;
 }
 
+WinClassicTheme.prototype.commit = function() {
+  Theme.prototype.commit.call(this);
+  this.undoButton.disabled = this.history.length <= 1;
+}
+
 WinClassicTheme.prototype.undo = function() {
   Theme.prototype.undo.call(this);
   this.updateStylesheet();
   this.resetPickers();
   this.displayExport();
+  this.undoButton.disabled = this.history.length <= 1;
 }
 
 return WinClassicTheme;

--- a/scripts/winclassic.js
+++ b/scripts/winclassic.js
@@ -119,7 +119,7 @@ WinClassicTheme.prototype.onColorChange = function(e) {
   this.resetPickers();
 }
 
-WinClassicTheme.prototype.onColorCommit = function(e) {
+WinClassicTheme.prototype.onColorCommit = function() {
   this.displayExport();
   this.commit();
 }

--- a/scripts/winclassic.js
+++ b/scripts/winclassic.js
@@ -72,7 +72,7 @@ function WinClassicTheme() {
     this.updateFromStylesheet(itemName);
     picker.value = this.getItemColor(itemName);
     picker.oninput = this.onColorChange.bind(this);
-    picker.onchange = this.displayExport.bind(this);
+    picker.onchange = this.onColorCommit.bind(this);
   }
 
   document.getElementById("import-action").onclick = function(e) {
@@ -91,6 +91,7 @@ function WinClassicTheme() {
   this.displayExport();
   updateLinkedElements();
 
+  this.commit();
   return this;
 }
 
@@ -109,6 +110,11 @@ WinClassicTheme.prototype.onColorChange = function(e) {
   this.setItemColor(name, color);
   this.updateStylesheet();
   this.resetPickers();
+}
+
+WinClassicTheme.prototype.onColorCommit = function(e) {
+  this.displayExport();
+  this.commit();
 }
 
 WinClassicTheme.prototype.exportToIni = function() {
@@ -141,6 +147,7 @@ WinClassicTheme.prototype.importIniSection = function(content) {
     this.updateStylesheet(item);
   }
   this.resetPickers();
+  this.commit();
   this.displayExport();
 }
 

--- a/scripts/winclassic.js
+++ b/scripts/winclassic.js
@@ -180,7 +180,7 @@ WinClassicTheme.prototype.enableLinkedElements = function(types) {
 
 WinClassicTheme.prototype.commit = function() {
   Theme.prototype.commit.call(this);
-  this.undoButton.disabled = this.history.undoLength <= 1;
+  this.undoButton.disabled = this.history.undoLength <= 0;
   this.redoButton.disabled = this.history.redoLength <= 0;
 }
 
@@ -189,7 +189,7 @@ WinClassicTheme.prototype.undo = function() {
   this.updateStylesheet();
   this.resetPickers();
   this.displayExport();
-  this.undoButton.disabled = this.history.undoLength <= 1;
+  this.undoButton.disabled = this.history.undoLength <= 0;
   this.redoButton.disabled = this.history.redoLength <= 0;
 }
 
@@ -198,7 +198,7 @@ WinClassicTheme.prototype.redo = function() {
   this.updateStylesheet();
   this.resetPickers();
   this.displayExport();
-  this.undoButton.disabled = this.history.undoLength <= 1;
+  this.undoButton.disabled = this.history.undoLength <= 0;
   this.redoButton.disabled = this.history.redoLength <= 0;
 }
 


### PR DESCRIPTION
Implement undo and redo functionality and expose it in the UI through Undo and Redo buttons. Accesskeys `u` and `r` have been added as poor-man's keybinds.

To do this, a new `ThemeHistory` module was added that contains two stacks, one for undo and another for redo. The `Theme` class instantiates a copy, exposes it through the `history` property, and implements the `commit`, `undo` and `redo` methods for managing `this.items`. The `WinClassicTheme` overrides these methods to also update the UI.

Resolves #6

<img width="236" height="84" alt="image" src="https://github.com/user-attachments/assets/8048acfb-bab5-4ccb-a603-4d6e4c32622a" />
